### PR TITLE
Update sites.json [animeblkom, anime4up and animezid]

### DIFF
--- a/plugin.video.matrix/resources/sites.json
+++ b/plugin.video.matrix/resources/sites.json
@@ -53,12 +53,12 @@
         "animeblkom": {
             "label": "Animeblkom",
             "active": "True",
-            "url": "https://animeblkom.net/"
+            "url": "https://blkom.com/"
         },
         "animeup": {
             "label": "Anime4up",
             "active": "True",
-            "url": "https://w1.anime4up.tv/"
+            "url": "https://anime4up.com/"
         },
         "animezid": {
             "label": "Animezid",

--- a/plugin.video.matrix/resources/sites.json
+++ b/plugin.video.matrix/resources/sites.json
@@ -63,7 +63,7 @@
         "animezid": {
             "label": "Animezid",
             "active": "True",
-            "url": "https://animezid.net/"
+            "url": "https://animezid.org/"
         },
         "arabsciences": {
             "label": "Arabsciences",


### PR DESCRIPTION
السلام عليكم,  تعديلات بسيطة، فقط لروابط مواقع تالفة.

المواقع المذكورة بالعنوان لم تكن تعمل للأسباب التالية:

- انمي بالكوم:  اصبح محجوب في اغلب المناطق حسب كلام ادمن الموقع وتم تحويله الى blkom.com.
- انمي4اب: الرابط لم يعد يعمل.
- انمي زيد: الرابط كان محجوب.
